### PR TITLE
Recast as a stand alone document

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 The CFA (Climate and Forecast Aggregation) conventions are designed
 for storing a netCDF file which does not contain the data of selected
 variables ("aggregation variables"), rather those variables contain
-special metadata that provide instructions on how to create their data
-as an aggregation of data from other sources, which may be
+special attributes that provide instructions on how to create their
+data as an aggregation of data from other sources, which may be
 self-describing datasets in their own right.
 
 In general, netCDF variables always contain their own data and

--- a/README.md
+++ b/README.md
@@ -1,4 +1,30 @@
-# CFA Conventions
+# NetCDF Climate and Forecast Aggregation (CFA) Conventions
 
-Conventions for the storage of aggregation variables within CF-netCDF
-datasets.
+The CFA (Climate and Forecast Aggregation) conventions are designed
+for storing a netCDF file which does not contain the data of selected
+variables ("aggregation variables"), rather those variables contain
+special metadata that provide instructions on how to create their data
+as an aggregation of data from other sources, which may be
+self-describing datasets in their own right.
+
+In general, netCDF variables always contain their own data and
+dimensions. An aggregation variable, however, does not contain its
+data&mdash;and therefore nor its dimensions&mdash;in the usual manner
+and yet still needs to be viewable as if it were a usual netCDF
+variable. This is achieved by encoding the aggregation variable as a
+scalar variable (with arbitrary single value) and providing extra
+variable attributes from which the variable's true dimensionality can
+be inferred, and the variable's aggregated data can be constructed.
+
+The CFA conventions only apply to the data definition of selected
+variables, so the CFA conventions have been designed to work alongside
+the CF (Climate and Forecast) conventions that specify the geophysical
+meaning of all variables in the file, whether their data are defined
+as aggregations or not. The CFA conventions do not duplicate, extend,
+nor re-define any of the metadata elements defined by the CF
+conventions. However, when CF-compliant software is used for reading
+the discovery metadata of a CFA-netCDF file, with no expectation of
+reading the data of aggregated variables, a small extension is needed
+to allow the correct interpretation of the dimensionality of
+aggregation variables.
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # NetCDF Climate and Forecast Aggregation (CFA) Conventions
 
-The CFA (Climate and Forecast Aggregation) conventions are designed
-for storing a netCDF file which does not contain the data of selected
-variables ("aggregation variables"), rather those variables contain
-special attributes that provide instructions on how to create their
-data as an aggregation of data from other sources, which may be
+The CFA (Climate and Forecast Aggregation) conventions describe how a
+netCDF file can be used to describe a dataset distributed across
+multiple other data files. A CFA-compliant aggregation can be
+described in netCDF in such way that the describing file does not
+contain the data of selected variables ("aggregation variables"),
+rather it contains variables with special attributes that provide
+instructions on how to create the aggregated variable data as an
+aggregation of data from other sources, each of which may be
 self-describing datasets in their own right.
 
 In general, netCDF variables always contain their own data and

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -3,7 +3,7 @@
 David Hassell, Jonathan Gregory, Neil Massey, Bryan Lawrence, Sadie
 Bartholomew
 
-**Version 0.6, 2021-06-??**
+**Version 0.6, 2021-06-21**
 
 
 ## Introduction
@@ -951,7 +951,7 @@ Prototype version
 Prototype version. First introduction of `location`, `file`, `format`
 and `address` variables.
 
-**Version 0.6, 2021-06-??**
+**Version 0.6, 2021-06-21**
 
 First stable release.
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -287,9 +287,7 @@ instruction terms, all of which are mandatory, are:
 An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
 and the whole of the other three aggregated dimensions, and is stored
-in an external netCDF file in a variable call `temp`. As all of the
-external files are netCDF files, the `format` term of the
-**`aggregated_data`** attribute is not required.
+in an external netCDF file in a variable call `temp`.
 
     dimensions:
       // Aggregated dimensions
@@ -314,6 +312,7 @@ external files are netCDF files, the `format` term of the
         temp:aggregated_dimensions = "time level latitude longitude" ;
         temp:aggregated_data = "location: aggregation_location
                                 file: aggregation_file
+                                format: aggregation_format
                                 address: aggregation_address" ;
       // Coordinate variables
       double time(time) ;
@@ -344,6 +343,7 @@ external files are netCDF files, the `format` term of the
                              0, 72,
                              0, 143 ;
       aggregation_file = "January-June.nc", "July-December.nc" ;
+      aggregation_format = "nc", "nc" ;
       aggregation_address = "temp", "temp" ;
 
 
@@ -448,11 +448,9 @@ An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
 and the whole of the other three aggregated dimensions. One fragment
 is stored in an external file and the other is stored in the same
-dataset as variable `temp2`. As all of the external files are netCDF
-files, the `format` term of the **`aggregated_data`** attribute is not
-required. The fragment stored in the same dataset has different but
-equivalent units to the aggregation variable, and omits the size 1
-`level` dimension.
+dataset as variable `temp2`. The fragment stored in the same dataset
+has different but equivalent units to the aggregation variable, and
+omits the size 1 `level` dimension.
 
     dimensions:
       // Aggregated dimensions
@@ -477,6 +475,7 @@ equivalent units to the aggregation variable, and omits the size 1
         temp:aggregated_dimensions = "time level latitude longitude" ;
         temp:aggregated_data = "location: aggregation_location
                                 file: aggregation_file
+                                format: aggregation_format
                                 address: aggregation_address" ;
       // Coordinate variables
       double time(time) ;
@@ -494,6 +493,7 @@ equivalent units to the aggregation variable, and omits the size 1
       // Aggregation definition variables			 	  
       int aggregation_location(f_time, f_level, f_latitude, f_longitude, i, j) ;
       string aggregation_file(f_time, f_level, f_latitude, f_longitude) ;
+      string aggregation_format(f_time, f_level, f_latitude, f_longitude) ;
       string aggregation_address(f_time, f_level, f_latitude, f_longitude) ;
       // Fragment variable
       double temp2(time, latitude, longitude) ;
@@ -511,6 +511,7 @@ equivalent units to the aggregation variable, and omits the size 1
                              0, 72,
                              0, 143 ;
       aggregation_file = "January-June.nc", _ ;
+      aggregation_format = "nc", _ ;
       aggregation_address = "temp", "temp2" ;
       temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
 
@@ -522,10 +523,10 @@ fragments. Each fragment is stored in the same dataset and spans half
 of the aggregated `time` dimension and the whole of the `latitude` and
 `longitude` dimensions, but does not span the size 1 `level`
 dimension. As there are no external files, the `file` and `format`
-terms of the **`aggregated_data`** attribute are not required. The
-fragments and aggregation definition variables in this case are stored
-in a child group called `aggregation`. The `temp2` fragment has
-different but equivalent units to the aggregation variable.
+variables both contain missing data. The fragments and aggregation
+definition variables in this case are stored in a child group called
+`aggregation`. The `temp2` fragment has different but equivalent units
+to the aggregation variable.
 
     dimensions:
       // Aggregated dimensions
@@ -541,6 +542,8 @@ different but equivalent units to the aggregation variable.
         temp:cell_methods = "time: mean" ;
         temp:aggregated_dimensions = "time level latitude longitude" ;
         temp:aggregated_data = "location: /aggregation/location
+                                file: /aggregation/file
+                                format: /aggregation/format
                                 address: /aggregation/address" ;
       // Coordinate variables
       double time(time) ;
@@ -572,6 +575,8 @@ different but equivalent units to the aggregation variable.
       variables:
         // Aggregation definition variables
         int location(f_time, f_level, f_latitude, f_longitude, i, j) ;
+        string file(f_time, f_level, f_latitude, f_longitude) ;
+        string format(f_time, f_level, f_latitude, f_longitude) ;
         string address(f_time, f_level, f_latitude, f_longitude) ;
         // Fragment variables
         double temp1(time, latitude, longitude) ;
@@ -588,6 +593,8 @@ different but equivalent units to the aggregation variable.
                    0, 0,
                    0, 72,
                    0, 143 ;
+       file = _, _ ;
+       format = _, _ ;
        address = "temp1", "temp2" ;
        temp1 = 270.3, 272.5, 274.1, 278.5, 280.3, 283.6, ... ;
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
@@ -623,6 +630,7 @@ used in the aggregated data.
         temp:aggregated_dimensions = "time level latitude longitude" ;
         temp:aggregated_data = "location: /aggregation/location
                                 file: /aggregation/file
+                                format: /aggregation/format
                                 address: /aggregation/address" ;
       // Coordinate variables
       double time(time) ;
@@ -659,6 +667,7 @@ used in the aggregated data.
         // Aggregation definition variables			 	  
         int location(f_time, f_level, f_latitude, f_longitude, i, j) ;
         string file(f_time, f_level, f_latitude, f_longitude, k) ;
+	string format(f_time, f_level, f_latitude, f_longitude, k) ;
         string address(f_time, f_level, f_latitude, f_longitude, k) ;
         // Fragment variable
         double temp2(time, latitude, longitude) ;
@@ -686,6 +695,10 @@ used in the aggregated data.
               _, _,
               "/local/January-June_NH.nc", "/remote/January-June_NH.nc",
               "/remote/July-December_NH.nc", _ ;
+       format = "nc, _,
+                _, _,
+                "nc", "nc",
+                "nc", _ ;
        address = "temp1", _,
                  "temp2", _,
                  "temp3", "t3",
@@ -726,7 +739,8 @@ apply to both aggregation variables.
         temp:cell_methods = "time: mean" ;
         temp:aggregated_dimensions = "time level latitude longitude" ;
         temp:aggregated_data = "location: /aggregation_temp/location
-                                file: aggregation_file	
+                                file: aggregation_file
+                                format: aggregation_format
                                 address: /aggregation_temp/address" ;
       // Coordinate variables
       double time ;
@@ -734,7 +748,8 @@ apply to both aggregation variables.
         time:units = "days since 2001-01-01" ;
         temp:aggregated_dimensions = "time" ;
         temp:aggregated_data = "location: /aggregation_time/location
-                                file: aggregation_file	
+                                file: aggregation_file
+				format: aggregation_format
                                 address: /aggregation_time/address" ;
       double level(level) ;
         level:standard_name = "height_above_mean_sea_level" ;
@@ -752,6 +767,7 @@ apply to both aggregation variables.
       temp = _ ;
       time = _ ;
       aggregation_file = "January-June.nc", "July-December.nc" ;
+      aggregation_format = "nc", "nc" ;
 
     group: aggregation_temp {
       variables:

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -763,7 +763,7 @@ apply to both aggregation variables.*
         temp:aggregated_dimensions = "time" ;
         temp:aggregated_data = "location: /aggregation_time/location
                                 file: /aggregation_time/file
-				format: agregation_format
+                                format: agregation_format
                                 address: /aggregation_time/address" ;
       double level(level) ;
         level:standard_name = "height_above_mean_sea_level" ;
@@ -803,7 +803,7 @@ apply to both aggregation variables.*
     group: aggregation_time {
       variables:
         // Time aggregation definition variables
-        int location(i, j) ;
+        int location(ii, j) ;
         string aggregation_file(f_time) ;
         string address(f_time) ;
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -349,7 +349,7 @@ external files are netCDF files, the `format` term of the
 
 ## Fragment Storage
 
-Each fragment has a generic form for which:
+Each fragment has a canonical form for which:
 
 * The fragment's data provides the values for a unique part of the
   aggregated data, as defined by the `location` term of the
@@ -373,11 +373,14 @@ Each fragment has a generic form for which:
   variables associated with the fragment (such as coordinate
   variables), are ignored by the aggregation variable.
 
-In limited circumstances, however, a fragment may deviate from these
-requirements providing that it is possible to unambiguously convert
-the fragment to its generic form prior to it being used within the
-aggregated data. This manipulation of the fragment is carried out by
-the application program that is managing the aggregation.
+In particular circumstances, however, a fragment may deviate from
+these requirements providing that it is possible to unambiguously
+convert the fragment to its canonical form prior to it being used
+within the aggregated data. This allows the usability of a fragment in
+the aggregated data to be independent of the fragment's encoding in
+its file. The manipulation of a fragment to its generic form is
+carried out by the application program that is managing the
+aggregation.
 
 The following fragment manipulations are allowed:
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -79,7 +79,7 @@ CF-1.9 and also CFA-0.6 could have a **`Conventions`** attribute of
 
 ## Aggregation variables
 
-A *aggregation variable* does not contain its own data, as is usual
+An *aggregation variable* does not contain its own data, as is usual
 for netCDF variables, instead it contains instructions on how to
 create its data as an aggregation of data from other sources.
 
@@ -583,7 +583,7 @@ to the aggregation variable.
        address = "temp1", "temp2" ;
        temp1 = 270.3, 272.5, 274.1, 278.5, 280.3, 283.6, ... ;
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
-
+    }
 
 #### Example 4
 
@@ -687,7 +687,7 @@ not both, may be used in the aggregated data.
                  "temp3", "t3",
                  "temp4", _ ;
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
-
+    }
 
 #### Example 5
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -24,6 +24,15 @@ arbitrary single value) and providing extra variable attributes from
 which the variable's true dimensionality can be inferred, and the
 variable's aggregated data can be constructed.
 
+In general, netCDF variables always contain their own data and
+dimensions. An aggregation variable, however, does not contain its
+data&mdash;and therefore nor its dimensions&mdash;in the usual manner yet
+still needs to be viewable as if it were a usual netCDF. This is
+achieved by converting the variable to be scalar (with arbitrary
+single value) and providing extra variable attributes from which the
+variable's true dimensionality can be inferred, and the variable's
+aggregated data can be constructed.
+
 The CFA conventions only apply to the data definition of selected
 variables, so the CFA conventions have been designed to work alongside
 the CF (Climate and Forecast) conventions that specify the geophysical

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -321,6 +321,7 @@ in an external netCDF file in a variable call `temp`.*
       // Aggregation definition variables			 	  
       int aggregation_location(f_time, f_level, f_latitude, f_longitude, i, j) ;
       string aggregation_file(f_time, f_level, f_latitude, f_longitude) ;
+      string aggregation_format(f_time, f_level, f_latitude, f_longitude) ;
       string aggregation_address(f_time, f_level, f_latitude, f_longitude) ;
 
     // global attributes:
@@ -398,7 +399,7 @@ For reference time units, the calendar of the aggregation variable and
 the calendars of the fragments must also be equivalent.
 
 For instance, if the aggregation variable units are "`days since
-2001-01-01`" in the Gregorian calendar and a fragment has units of
+2001-01-01`" in the CF standard calendar and a fragment has units of
 "`days since 2002-01-01`" in the same calendar, then the reference
 time of the fragment's units are changed to the earlier date by adding
 365 to the fragment's data.

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -3,7 +3,7 @@
 David Hassell, Jonathan Gregory, Neil Massey, Bryan Lawrence, Sadie
 Bartholomew
 
-Version 0.6, 2021-06-??
+**Version 0.6, 2021-06-??**
 
 ## Introduction
 
@@ -41,27 +41,27 @@ also has dimensions but no data).
 ## Identification of Conventions
 
 Files that follow this version of the CFA Conventions must indicate
-this by setting the NetCDF User’s Guide (NUG) [NUG] defined global
-attribute **`Conventions`** to a string value that contains
-`"CFA-0.6"`, in addition to any other conventions that define other
-aspects of the file structure and metadata. For instance, a dataset
-which follows CF-1.9 and also CFA-0.6 could have a **`Conventions`**
-attribute of `"CF-1.9 CFA-0.6"`.
+this by setting the NetCDF User’s Guide [NUG] defined global attribute
+**`Conventions`** to a string value that contains `"CFA-0.6"`, in
+addition to any other conventions that define other aspects of the
+file structure and metadata. For instance, a dataset which follows
+CF-1.9 and also CFA-0.6 could have a **`Conventions`** attribute of
+`"CF-1.9 CFA-0.6"`.
 
 
 ## Terminology
-
-**aggregated data**
-
-The data of an *aggregation variable* that exists as a set of
-instructions on how to build an array from one or more other arrays
-stored elsewhere.
 
 **aggregation variable**
 
 A netCDF variable that does not contain its own data, rather it
 contains instructions on how to create its data as an aggregation of
 data from other sources.
+
+**aggregated data**
+
+The data of an *aggregation variable* that exists as a set of
+instructions on how to build an array from one or more other arrays
+stored elsewhere.
 
 **fragment**
 
@@ -74,16 +74,11 @@ composed from a multi-dimensional orthogonal array of fragments.
 A dimension of the multi-dimensional orthogonal array of fragments
 that defines the *aggregated data*.
 
-**parent file**
-
-The netCDF file that contains the *aggregated variable*, and may also
-contain some or all of the *fragments*.
-
 
 ## Aggregation variables
 
 A *aggregation variable* does not contain its own data, as is usual
-for CF-netCDF variables, instead it contains instructions on how to
+for netCDF variables, instead it contains instructions on how to
 create its data as an aggregation of data from other sources.
 
 When created by an application program, the data of an aggregation
@@ -127,7 +122,7 @@ dimensions perform that role for a usual CF-netCDF variable. For
 instance, all variables named by the **`cell_measures`** attribute of
 an aggregated data variable must span a subset of zero or more of the
 dimensions given by the **`aggregated_dimensions`** attribute; or the
-variable named by the **`bounds`** attribute of an aggregated
+variable named by the **`bounds`** attribute of an aggregated CF
 coordinate variable must span all of the aggregated dimensions in the
 same order, as well as the trailing bounds dimension. Any CF
 coordinate variable that shares its name with an aggregated dimension
@@ -143,7 +138,7 @@ the number of fragments that span its corresponding aggregated
 dimension. For instance, if an aggregated dimension of size 100 has
 been fragmented into three fragments spanning 20 values each and one
 fragment spanning 40 values, then the corresponding fragment dimension
-will have size 4; an aggregated dimension of any size may be
+will have size 4. An aggregated dimension of any size may be
 associated with a fragment dimension of size 1. The fragments must be
 arranged in the same relative multidimensional order as their
 positions in the aggregated data.
@@ -164,11 +159,14 @@ are allowed or required by the aggregation instruction. No other
 dimensions may be spanned by variables containing aggregation
 instructions.
 
-The value of a `term` token identifying an aggregation instruction
-may be standardized or non-standardized, with the understanding that
+The value of a `term` token identifying an aggregation instruction may
+be standardized or non-standardized, with the understanding that
 application programs should ignore terms that they do not recognise or
-which are irrelevant for their purposes. The standardized aggregation
-instruction terms, all of which are mandatory, are:
+which are irrelevant for their purposes. The purpose of allowing
+non-standardized tokens is to facilitate the aggregation of fragments
+stored in other file formats to those described by these
+conventions. The standardized aggregation instruction terms, all of
+which are mandatory, are:
 
 `location`
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -942,7 +942,6 @@ values 270.0, 270.1, ... 271.1.
         file = _, _ ;
         format = _, _ ;
         address = "/aggregation/temp1", "/aggregation/temp2" ;
-   }
 
 
 ## Revision History

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -5,6 +5,7 @@ Bartholomew
 
 **Version 0.6, 2021-06-??**
 
+
 ## Introduction
 
 This document describes the CFA (Climate and Forecast Aggregation)
@@ -358,11 +359,12 @@ Each fragment has a canonical form for which:
 In particular circumstances, however, a fragment may deviate from
 these requirements providing that it is possible to unambiguously
 convert the fragment to its canonical form prior to it being used
-within the aggregated data. This is useful for cases when the framents
-were created independently of the CFA-netCDF file and were encoded
-with forms which are equivalent, but not equal to, the canonical
-form. The manipulation of a fragment to its canonical form is carried
-out by the application program that is managing the aggregation.
+within the aggregated data. This is useful for cases when the
+fragments were created independently of the CFA-netCDF file and were
+encoded with forms which are equivalent, but not equal to, the
+canonical form. The manipulation of a fragment to its canonical form
+is carried out by the application program that is managing the
+aggregation.
 
 The following fragment manipulations are allowed:
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -606,14 +606,12 @@ An aggregated data variable whose aggregated data comprises four
 fragments. Each fragment spans half of the aggregated `time`
 dimension, either the northern or southern hemisphere, and the whole
 of the other two aggregated dimensions. The fragments are stored in
-external netCDF files. As all of the external files are netCDF files,
-the `format` term of the **`aggregated_data`** attribute is not
-required. The aggregation definition variables are stored in a child
-group called `aggregation`. One of the fragments has been defined by
-two different external resources (one "local" and one "remote"), each
-of which is provided with its own address within its file (`temp3` and
-`t3` respectively). Either of these resources, but not both, may be
-used in the aggregated data.
+external netCDF files. The aggregation definition variables are stored
+in a child group called `aggregation`. One of the fragments has been
+defined by two different external resources (one "local" and one
+"remote"), each of which is provided with its own address within its
+file (`temp3` and `t3` respectively). Either of these resources, but
+not both, may be used in the aggregated data.
 
     dimensions:
       // Aggregated dimensions

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -948,8 +948,7 @@ values 270.0, 270.1, ... 271.1.
 ## Revision History
 
 _Versions 0.1 to 0.3, 2012 to 2013_
-
-Prototype versions
+: Prototype versions
 
 _Version 0.4, 2014-02-27_
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -942,7 +942,7 @@ values 270.0, 270.1, ... 271.1.
         file = _, _ ;
         format = _, _ ;
         address = "/aggregation/temp1", "/aggregation/temp2" ;
-
+    }
 
 ## Revision History
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -947,17 +947,17 @@ values 270.0, 270.1, ... 271.1.
 
 ## Revision History
 
-**Versions 0.1 to 0.3, 2012 to 2013 **
+**Versions 0.1 to 0.3, 2012 to 2013\ **
 Prototype versions
 
-**Version 0.4, 2014-02-27 **
+**Version 0.4, 2014-02-27\ **
 Prototype version
 
-**Version 0.5, 2021 **
+**Version 0.5, 2021\ **
 Prototype version. First introduction of `location`, `file`, `format`
 and `address` variables.
 
-**Version 0.6, 2021-06-?? **
+**Version 0.6, 2021-06-??\ **
 First stable release.
 
 ## References

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -957,7 +957,7 @@ First stable release.
 
 ## References
 
-[CF] NetCDF Climate and Forecast (CF) Metadata Conventions. https://cfconventions.org/cf-conventions/cf-conventions.html
+[CF] NetCDF Climate and Forecast (CF) Metadata Conventions. https://cfconventions.org
 
 [NetCDF] NetCDF Software Package. UNIDATA Program Center of the University Corporation for Atmospheric Research. http://www.unidata.ucar.edu/netcdf/index.html
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -20,9 +20,9 @@ In general, netCDF variables always contain their own data and
 dimensions. An aggregation variable, however, does not contain its
 data&mdash;and therefore nor its dimensions&mdash;in the usual manner
 and yet still needs to be viewable as if it were a usual netCDF
-variable. This is achieved by converting the variable to be scalar
-(with arbitrary single value) and providing extra variable attributes
-from which the variable's true dimensionality can be inferred, and the
+variable. This is achieved by encoding the variable as a scalar (with
+arbitrary single value) and providing extra variable attributes from
+which the variable's true dimensionality can be inferred, and the
 variable's aggregated data can be constructed.
 
 The CFA conventions only apply to the data definition of selected

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -16,8 +16,8 @@ conventions for storing climate and forecast datasets which do not
 contain the data of selected variables, rather those variables contain
 metadata that provide instructions on how to create their data as an
 aggregation of data from other sources. The CFA conventions are only
-concerned with the aggregation of external data sources, and so must
-be used in conjunction with the CF (Climate and Forecast) metadata
+concerned with the aggregation of external data sources, and must be
+used in conjunction with the CF (Climate and Forecast) metadata
 conventions, that provide all of the metadata required to physically
 interpret geoscientific variables.
 
@@ -27,16 +27,35 @@ interpret geoscientific variables.
 
 Some backgound here ... on the need and what the CFA convnetions provide
 
+When a variable's data may be wholly specified by the aggregation of
+the data of other variables, the CFA (Climate and Forecast
+Aggregation) conventions provide a framework for describing how to
+create that aggregation, and this may be used instead of creating the
+entire aggregation in the file as the variable's data as is ususal in
+netCDF files. A variable encoded in this manner is called an
+"aggregation variable".
 
-The CF (Climate and Forecast) metadata conventions are designed to
-describe the geoscientific nature of climate and forecast data,
-i.e. for a netCDF data variable, they provide a description of the
-physical meaning of data and of its spatial, temporal, and other
-dimensional properties. The CFA (Climate and Forecast Aggregation)
-conventions described here are, by contrast, only concerned with the
-storage of the *data*, rather than the *metadata*, of selected netCDF
-variables. The CFA conventions do not duplicate nor re-define any of
-the metadata elements defined by the CF conventions.
+In general, netCDF variables always contain their own data and
+dimensions, but for an aggregation variable no actual data in the file
+is required. At the same time, an aggregation variable needs to be
+viewable as if it were encoded as a normal netCDF variable, i.e. one
+with data and their associated netCDF dimensions in the file. To
+provide this functionality the CFA framework essentially converts the
+variable to be scalar (with arbitrary single value) and provides extra
+attributes that identify the variable as an aggregation variable and
+from which both the variable's true dimensionality can be inferred,
+and the aggregeted data can be constructed.
+
+The CFA conventions only apply to the data definition of individual
+variables, so the CFA conventions have been designed to work alongside
+the CF (Climate and Forecast) conventions that specify the geophysical
+meaning of all variables in the file, whether their data are defined
+as aggregations or not. The CFA conventions do not duplicate nor
+re-define any of the metadata elements defined by the CF conventions,
+but a small extension to CF is needed to allow the interpretation of
+the metadata when the data is not present in the file (effectively a
+duplication of the functionality introduced in CF-1.9 for the domain
+variable)
 
 ---
 
@@ -45,9 +64,9 @@ the metadata elements defined by the CF conventions.
 Files that follow this version of the CFA Conventions must indicate
 this by setting the CF defined global attribute **`Conventions`** to a
 string value that contains `"CFA-0.6"`, in addition to the version of
-the CF conventions that, where not superceded by the CFA conventions,
-define the file structure and metadata. For instance, a dataset which
-follows CF-1.9 and also CFA-0.6 could have a **`Conventions`**
+the CF conventions that otherwise define the file structure and
+geophysical metadata. For instance, a dataset which follows CF-1.9 and
+also, for some of its variables, CFA-0.6 could have a **`Conventions`**
 attribute of `"CF-1.9 CFA-0.6"`.
 
 ---

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -5,54 +5,40 @@ Bartholomew
 
 Version 0.6, 2021-06-??
 
-
-## Abstract
-
-This document describes the CFA (Climate and Forecast Aggregation)
-conventions for storing netCDF climate and forecast datasets which do
-not contain the data of selected variables, rather those variables
-contain metadata that provide instructions on how to create their data
-as an aggregation of data from other sources. The CFA conventions are
-only concerned with the aggregation of external data sources, and must
-be used in conjunction with the CF (Climate and Forecast) metadata
-conventions, that provide all of the metadata required to physically
-interpret geoscientific variables.
-
-
 ## Introduction
 
-Some backgound here ... 
-
-When a netCDF variable's data may be wholly specified by the
-aggregation of the data of other variables, the CFA (Climate and
-Forecast Aggregation) conventions provide a framework for describing
-how to create that aggregation, and this may be used instead of
-creating the entire aggregation in the file as the variable's data, as
-is ususal in netCDF files. A variable encoded in this manner is called
-an "aggregation variable".
+This document describes the CFA (Climate and Forecast Aggregation)
+conventions for storing a netCDF climate and forecast file which does
+not contain the data of selected variables ("aggregation variables"),
+rather those variables contain special metadata that provide
+instructions on how to create their data as an aggregation of data
+from other sources, which may be self-describing datasets in their own
+right.
 
 In general, netCDF variables always contain their own data and
-dimensions, but for an aggregation variable no actual data in the file
-is required. At the same time, an aggregation variable needs to be
-viewable as if it were encoded as a normal netCDF variable, i.e. one
-with data and their associated netCDF dimensions in the file. To
-provide this functionality the CFA framework essentially converts the
-variable to be scalar (with arbitrary single value) and provides extra
-attributes that identify the variable as an aggregation variable and
-from which both the variable's true dimensionality can be inferred,
-and the aggregeted data can be constructed.
+dimensions. An aggregation variable, however, still needs to be
+viewable as if it were a usual netCDF variable even though it does not
+contain its data and dimensions in the usual manner. This is achieved
+by converting the variable to be scalar (with arbitrary single value)
+and providing extra variable attributes from which both the variable's
+true dimensionality can be inferred, and the variable's aggregeted
+data can be constructed.
 
-The CFA conventions only apply to the data definition of individual
+The CFA conventions only apply to the data definition of selected
 variables, so the CFA conventions have been designed to work alongside
 the CF (Climate and Forecast) conventions that specify the geophysical
 meaning of all variables in the file, whether their data are defined
 as aggregations or not. The CFA conventions do not duplicate nor
 re-define any of the metadata elements defined by the CF conventions,
-but a small extension to CF is needed to allow the interpretation of
-the metadata when the data is not present in the file (effectively a
-duplication of the functionality introduced in CF-1.9 for the domain
-variable)
+but a small extension to CF is needed to allow the correct
+interpretation of the dimensionality of aggregation variables
+(effectively a duplication of the functionality introduced in CF-1.9
+for the domain variable, which also has dimensions but no data).
 
+A CFA-netCDF file is a view of a dataset that has been distributed
+across multiple files and storage systems, which contains exactly the
+same information as the dataset that could be created by copying all
+of the distributed files into a single CF-netCDF file.
 
 ## Identification of Conventions
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -948,9 +948,10 @@ values 270.0, 270.1, ... 271.1.
 ## Revision History
 
 **Versions 0.1 to 0.3, 2012 to 2013**
+
 Prototype versions
 
-**Version 0.4, 2014-02-27*8
+**Version 0.4, 2014-02-27**
 
 Prototype version
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -1,56 +1,142 @@
-# Aggregation Variables
+# CF Aggregation (CFA) Conventions
 
-*v0.1 - v0.4 David Hassell and Jonathan Gregory, 2012 - 2019*
+---
 
-*v0.5 Neil Massey, 2020*
+David Hassell, Jonathan Gregory, Neil Massey, Bryan Lawrence, Sadie
+Bartholomew
 
-*v0.6 David Hassell, Jonathan Gregory, Neil Massey, Bryan
- Lawrence and Sadie Bartholomew 2021-06-16*
+Version 0.6, 2021-06-??
 
-An *aggregation variable* does not contain its own data, rather it
+---
+
+## Abstract
+
+This document describes the CFA (Climate and Forecast Aggregation)
+conventions for storing climate and forecast datasets which do not
+contain the data of selected variables, rather those variables contain
+metadata that provide instructions on how to create their data as an
+aggregation of data from other sources. The CFA conventions are only
+concerned with the aggregation of external data sources, and so must
+be used in conjunction with the CF (Climate and Forecast) metadata
+conventions, that provide all of the metadata required to physically
+interpret geoscientific variables.
+
+---
+
+## Introduction
+
+Some backgound here ... on the need and what the CFA convnetions provide
+
+
+The CF (Climate and Forecast) metadata conventions are designed to
+describe the geoscientific nature of climate and forecast data,
+i.e. for a netCDF data variable, they provide a description of the
+physical meaning of data and of its spatial, temporal, and other
+dimensional properties. The CFA (Climate and Forecast Aggregation)
+conventions described here are, by contrast, only concerned with the
+storage of the *data*, rather than the *metadata*, of selected netCDF
+variables. The CFA conventions do not duplicate nor re-define any of
+the metadata elements defined by the CF conventions.
+
+---
+
+## Identification of Conventions
+
+Files that follow this version of the CFA Conventions must indicate
+this by setting the CF defined global attribute **`Conventions`** to a
+string value that contains `"CFA-0.6"`, in addition to the version of
+the CF conventions that, where not superceded by the CFA conventions,
+define the file structure and metadata. For instance, a dataset which
+follows CF-1.9 and also CFA-0.6 could have a **`Conventions`**
+attribute of `"CF-1.9 CFA-0.6"`.
+
+---
+
+## Terminology
+
+**aggregated data**
+
+The data of an *aggregation variable* that exists as a set of
+instructions on how to build an array from one or more other arrays
+stored elsewhere.
+
+**aggregation variable**
+
+A netCDF variable that does not contain its own data, rather it
 contains instructions on how to create its data as an aggregation of
-data from other sources. When created by an application program, the
-data of an aggregation variable is called its *aggregated data*. The
-aggregated data is composed of one or more *fragments*, each of which
-provides the values for a unique part of the aggregated data. Each
-fragment is contained in a file, either external to or shared by the
-dataset containing the aggregation variable; or else is assumed to
-contain wholly missing values.
+data from other sources.
+
+**fragment**
+
+An independent, possibly self-describing, array that defines a
+contiguous part of the *aggregated data*. The aggregated data is
+composed from a multi-dimensional orthogonal array of fragments.
+
+**fragment dimension**
+
+A dimension of the multi-dimensional orthogonal array of fragments
+that defines the *aggregated data*.
+
+**parent file**
+
+The netCDF file that contains the *aggregated variable*, and may also
+contain some or all of the *fragments*.
+
+---
+
+## Aggregation variables
+
+A *aggregation variable* does not contain its own data, as is ususal
+for CF-netCDF variables, instead it contains instructions on how to
+create its data as an aggregation of data from other sources.
+
+When created by an application program, the data of an aggregation
+variable is called its *aggregated data*. The aggregated data is
+composed of one or more *fragments*, each of which provides the values
+for a unique part of the aggregated data. Each fragment is contained
+in a file that is either external to, or shared by, the dataset
+containing the aggregation variable; or else is assumed to contain
+wholly missing values.
 
 An aggregation variable should be a scalar (i.e. it has no dimensions)
 and the value of its single element is immaterial. It acts as a
-container for the usual attributes that define the data (such as
+container for the usual CF attributes that define the data (such as
 **`standard_name`** and **`units`**), with the addition of special
 attributes that provide instructions on how to create the aggregated
 data. The data type of the aggregated data is the same as the data
 type of the aggregated variable.
 
 The dimensions of the aggregated data, called the *aggregated
-dimensions*, must exist as dimensions in the dataset containing the
-aggregation variable and must be stored with the
-**`aggregated_dimensions`** attribute. The presence of an
-**`aggregated_dimensions`** attribute will identify an aggregation
-variable, therefore the **`aggregated_dimensions`** attribute must not
-be present on any variables that do not have aggregated data. The
-value of the **`aggregated_dimensions`** attribute is a blank
-separated list of the aggregated dimension names given in the order
-which matches the dimensions of the aggregated data. If the aggregated
-data is scalar then the value of the **`aggregated_dimensions`**
-attribute must be an empty string.
+dimensions*, must be stored with the scalar aggregation variable's
+**`aggregated_dimensions`** attribute. The value of the
+**`aggregated_dimensions`** attribute is a blank separated list of the
+aggregated dimension names given in the order which matches the
+dimensions of the aggregated data. If the aggregated data is scalar
+then the value of the **`aggregated_dimensions`** attribute must be an
+empty string. The named aggregated dimensions must exist as dimensions
+in the netCDF dataset containing the aggregation variable.
+
+The effective dimensions of the aggregation variable are therefore
+found by inspecting the **`aggregated_dimensions`** attribute, rather
+than the variable's netCDF dimensions, as is usual for CF-netCDF
+variables. The presence of an **`aggregated_dimensions`** attribute
+will identify an aggregation variable, therefore the
+**`aggregated_dimensions`** attribute must not be present on any
+variables that do not have aggregated data.
 
 The dimensions listed by the **`aggregated_dimensions`** attribute
 constrain the dimensions that may be spanned by variables referenced
 from any of the other attributes, in the same way that the array
-dimensions perform that role for a non-aggregation variable. For
+dimensions perform that role for a ususal CF-netCDF variable. For
 instance, all variables named by the **`cell_measures`** attribute of
 an aggregated data variable must span a subset of zero or more of the
 dimensions given by the **`aggregated_dimensions`** attribute; or the
 variable named by the **`bounds`** attribute of an aggregated
 coordinate variable must span all of the aggregated dimensions in the
-same order, as well as the trailing bounds dimension. Any coordinate
-variable that shares its name with an aggregated dimension of an
-aggregated data variable will be considered as part of the data
-variable's domain definition.
+same order, as well as the trailing bounds dimension. Any CF
+coordinate variable that shares its name with an aggregated dimension
+of an aggregated data variable will be considered as part of the data
+variable's CF domain definition.
 
 The fragments are organised into an orthogonal multidimensional array
 with the same number of dimensions as the aggregated data. Each
@@ -183,7 +269,7 @@ instruction terms, all of which are mandatory, are:
 * Addressing for other file formats is allowed, but not described in
   these conventions.
 
-### Example 1
+#### Example 1
 
 An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
@@ -248,7 +334,7 @@ external files are netCDF files, the `format` term of the
       aggregation_address = "temp", "temp" ;
 
 
-## Fragment Storage
+### Fragment Storage
 
 Each fragment has a generic form for which:
 
@@ -282,7 +368,7 @@ the application program that is managing the aggregation.
 
 The following fragment manipulations are allowed:
 
-### Units
+#### Units
  
 If a fragment has no defined units then its data is assumed to have
 the same units as the aggregated variable.
@@ -306,7 +392,7 @@ For instance, if the aggregation variable units are `"days since
 of the fragment's units are changed to the earlier date by adding 365
 to the fragment's data.
 
-### Missing size 1 dimensions
+#### Missing size 1 dimensions
 
 A fragment may omit from its data any size 1 dimension for which the
 size of the fragment's location along the corresponding aggregated
@@ -316,7 +402,7 @@ instance, if the fragment's shape defined by the `location` term of
 the aggregation instructions is `(6, 1, 73, 144)`, then the fragment's
 data could have shape `(6, 1, 73, 144)` or `(6, 73, 144)`.
 
-### Compression
+#### Compression
 
 A fragment may be stored in any compressed form, i.e. stored using
 fewer bits than its original uncompressed representation, for which
@@ -328,7 +414,7 @@ prior to insertion into the aggregated data. In this case, the
 the uncompressed fragment and the data type of the fragment is the
 data type of its uncompressed data.
 
-### Missing values
+#### Missing values
 
 A fragment may use any valid means for defining missing
 values. Missing values must be changed to values that the aggregation
@@ -336,7 +422,7 @@ variable recognises as missing. It is up to the creator of the dataset
 to ensure that non-missing values in a fragment are not registered as
 missing in the aggregated data.
 
-### Example 2
+#### Example 2
 
 An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
@@ -409,7 +495,7 @@ equivalent units to the aggregation variable, and omits the size 1
       temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
 
 
-### Example 3
+#### Example 3
 
 An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment is stored in the same dataset and spans half
@@ -487,7 +573,7 @@ different but equivalent units to the aggregation variable.
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
 
 
-### Example 4
+#### Example 4
 
 An aggregated data variable whose aggregated data comprises four
 fragments. Each fragment spans half of the aggregated `time`
@@ -586,7 +672,7 @@ used in the aggregated data.
                  "temp4", _ ;
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
 
-### Example 5
+#### Example 5
 
 An aggregated data variable and an aggregated coordinate variable in
 the same dataset. There are two external netCDF files, each of which
@@ -676,7 +762,7 @@ apply to both aggregation variables.
         address = "time", "time" ;
    }
    
-### Example 6
+#### Example 6
 
 An aggregation data variable for a collection of discrete sampling
 geometry timeseries features that have been compressed by use of a
@@ -766,7 +852,7 @@ separate external file.
       aggregation_address_lon = "lon", "lon", "lon" ;
 
 
-### Example 7
+#### Example 7
 
 An aggregation data variable whose aggregated data represents 32-bit
 floats packed into 16-bit integers. When created, the aggregated data
@@ -828,34 +914,8 @@ values 270.0, 270.1, ... 271.1.
         format = _, _ ;
         address = "/aggregation/temp1", "/aggregation/temp2" ;
    }
-   
-## Glossary
 
-**aggregated data**
+---
 
-The data of an *aggregation variable* that exists as a set of
-instructions on how to build an array from one or more other arrays
-stored elsewhere.
-
-**aggregation variable**
-
-A netCDF variable that does not contain its own data, rather it
-contains instructions on how to create its data as an aggregation of
-data from other sources.
-
-**fragment**
-
-An independent, possibly self-describing, array that defines a
-contiguous part of the *aggregated data*. The aggregated data is
-composed from a multi-dimensional orthogonal array of fragments.
-
-**fragment dimension**
-
-A dimension of the multi-dimensional orthogonal array of fragments
-that defines the *aggregated data*.
-
-**parent file**
-
-The netCDF file that contains the *aggregated variable*, and may also
-contain some or all of the *fragments*.
+## References
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -26,12 +26,12 @@ variable's aggregated data can be constructed.
 
 In general, netCDF variables always contain their own data and
 dimensions. An aggregation variable, however, does not contain its
-data&mdash;and therefore nor its dimensions&mdash;in the usual manner yet
-still needs to be viewable as if it were a usual netCDF. This is
-achieved by converting the variable to be scalar (with arbitrary
-single value) and providing extra variable attributes from which the
-variable's true dimensionality can be inferred, and the variable's
-aggregated data can be constructed.
+data&mdash;and therefore nor its dimensions&mdash;in the usual manner
+and yet still needs to be viewable as if it were a usual netCDF
+variable. This is achieved by converting the variable to be scalar
+(with arbitrary single value) and providing extra variable attributes
+from which the variable's true dimensionality can be inferred, and the
+variable's aggregated data can be constructed.
 
 The CFA conventions only apply to the data definition of selected
 variables, so the CFA conventions have been designed to work alongside
@@ -53,7 +53,7 @@ Files that follow this version of the CFA Conventions must indicate
 this by setting the NetCDF User’s Guide (NUG) [NUG] defined global
 attribute **`Conventions`** to a string value that contains
 `"CFA-0.6"`, in addition to any other conventions that define other
-aspect of the file structure and metadata. For instance, a dataset
+aspects of the file structure and metadata. For instance, a dataset
 which follows CF-1.9 and also CFA-0.6 could have a **`Conventions`**
 attribute of `"CF-1.9 CFA-0.6"`.
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -70,11 +70,11 @@ that defines the *aggregated data*.
 
 Files that follow this version of the CFA Conventions must indicate
 this by setting the NetCDF User's Guide [NUG] defined global attribute
-**`Conventions`** to a string value that contains `"CFA-0.6"`, in
+**`Conventions`** to a string value that contains `CFA-0.6`, in
 addition to any other conventions that define other aspects of the
 file structure and metadata. For instance, a dataset which follows
 CF-1.9 and also CFA-0.6 could have a **`Conventions`** attribute of
-`"CF-1.9 CFA-0.6"`.
+`CF-1.9 CFA-0.6`.
 
 
 ## Aggregation variables
@@ -148,7 +148,7 @@ positions in the aggregated data.
 The definitions of the fragments and the instructions on how to
 aggregate them are provided by the **`aggregated_data`**
 attribute. This attribute takes a string value comprising
-blank-separated elements of the form `"term: variable"`, where `term`
+blank-separated elements of the form "`term: variable`", where `term`
 is a case-insensitive keyword that identifies a particular aggregation
 instruction, and `variable` is the name of a variable that configures
 that instruction for each fragment. The order of elements is not
@@ -225,7 +225,7 @@ which are mandatory, are:
   missing value.
   
 * A fragment in an external netCDF file is signified by a value of
-  `"nc"`.
+  `nc`.
 
 * Specification of other file formats is allowed, but not described in
   these conventions.
@@ -387,9 +387,9 @@ adding 32.
 For reference time units, the calendar of the aggregation variable and
 the calendars of the fragments must also be equivalent.
 
-For instance, if the aggregation variable units are `"days since
-2001-01-01"` in the Gregorian calendar and a fragment has units of
-`"days since 2002-01-1"` in the same calendar, then the reference time
+For instance, if the aggregation variable units are `days since
+2001-01-01` in the Gregorian calendar and a fragment has units of
+`days since 2002-01-1` in the same calendar, then the reference time
 of the fragment's units are changed to the earlier date by adding 365
 to the fragment's data.
 
@@ -956,7 +956,6 @@ and `address` variables.
 First stable release.
 
 ## References
-
 [CF] NetCDF Climate and Forecast (CF) Metadata Conventions. https://cfconventions.org
 
 [NetCDF] NetCDF Software Package. UNIDATA Program Center of the University Corporation for Atmospheric Research. http://www.unidata.ucar.edu/netcdf/index.html

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -3,7 +3,7 @@
 David Hassell, Jonathan Gregory, Neil Massey, Bryan Lawrence, Sadie
 Bartholomew
 
-**Version 0.6b1**
+**Version 0.6b1**, 2021-07-??
 
 
 ## Introduction
@@ -70,11 +70,11 @@ that defines the *aggregated data*.
 
 Files that follow this version of the CFA Conventions must indicate
 this by setting the NetCDF User's Guide [NUG] defined global attribute
-**`Conventions`** to a string value that contains `CFA-0.6`, in
+**`Conventions`** to a string value that contains "`CFA-0.6`", in
 addition to any other conventions that define other aspects of the
 file structure and metadata. For instance, a dataset which follows
 CF-1.9 and also CFA-0.6 could have a **`Conventions`** attribute of
-`CF-1.9 CFA-0.6`.
+"`CF-1.9 CFA-0.6`".
 
 
 ## Aggregation variables
@@ -390,14 +390,14 @@ adding 32.
 For reference time units, the calendar of the aggregation variable and
 the calendars of the fragments must also be equivalent.
 
-For instance, if the aggregation variable units are `days since
-2001-01-01` in the Gregorian calendar and a fragment has units of
-`days since 2002-01-1` in the same calendar, then the reference time
-of the fragment's units are changed to the earlier date by adding 365
-to the fragment's data.
+For instance, if the aggregation variable units are "`days since
+2001-01-01`" in the Gregorian calendar and a fragment has units of
+"`days since 2002-01-01`" in the same calendar, then the reference
+time of the fragment's units are changed to the earlier date by adding
+365 to the fragment's data.
 
 
-### Missing size 1 dimensions
+### Size 1 dimensions
 
 A fragment may omit from its data any size 1 dimension for which the
 size of the fragment's location along the corresponding aggregated

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -947,19 +947,21 @@ values 270.0, 270.1, ... 271.1.
 
 ## Revision History
 
-_Versions 0.1 to 0.3, 2012 to 2013_ 
+_Versions 0.1 to 0.3, 2012 to 2013_
+
 Prototype versions
 
-_Version 0.4, 2014-02-27_ 
+_Version 0.4, 2014-02-27_
+
 Prototype version
 
+_Version 0.5, 2021_
 
-
--Version 0.5, 2021_ 
 Prototype version. First introduction of `location`, `file`, `format`
 and `address` variables.
 
-_Version 0.6, 2021-06-??_ 
+_Version 0.6, 2021-06-??_
+
 First stable release.
 
 ## References

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -961,4 +961,4 @@ First stable release.
 
 [NetCDF] NetCDF Software Package. UNIDATA Program Center of the University Corporation for Atmospheric Research. http://www.unidata.ucar.edu/netcdf/index.html
 
-[NUG] The NetCDF User’s Guide for NetCDF version 4.4.1.1. http://www.unidata.ucar.edu/software/netcdf/docs/user_guide.html
+[NUG] NetCDF User’s Guide. https://www.unidata.ucar.edu/software/netcdf/documentation/NUG

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -21,9 +21,9 @@ dimensions. An aggregation variable, however, does not contain its
 data&mdash;and therefore nor its dimensions&mdash;in the usual manner
 and yet still needs to be viewable as if it were a usual netCDF
 variable. This is achieved by encoding the aggregation variable as a
-scalar (with arbitrary single value) and providing extra variable
-attributes from which the variable's true dimensionality can be
-inferred, and the variable's aggregated data can be constructed.
+scalar variable (with arbitrary single value) and providing extra
+variable attributes from which the variable's true dimensionality can
+be inferred, and the variable's aggregated data can be constructed.
 
 The CFA conventions only apply to the data definition of selected
 variables, so the CFA conventions have been designed to work alongside

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -3,7 +3,7 @@
 David Hassell, Jonathan Gregory, Neil Massey, Bryan Lawrence, Sadie
 Bartholomew
 
-**Version 0.6, 2021-06-21**
+**Version 0.6b1**
 
 
 ## Introduction
@@ -12,7 +12,7 @@ This document describes the CFA (Climate and Forecast Aggregation)
 conventions for storing a file created with the netCDF Application
 Programmer Interface [NetCDF] which does not contain the data of
 selected variables ("aggregation variables"), rather those variables
-contain special metadata that provide instructions on how to create
+contain special attributes that provide instructions on how to create
 their data as an aggregation of data from other sources, which may be
 self-describing datasets in their own right.
 
@@ -36,8 +36,8 @@ reading the discovery metadata of a CFA-netCDF file, with no
 expectation of reading the data of aggregated variables, a small
 extension is needed to allow the correct interpretation of the
 dimensionality of aggregation variables (effectively a duplication of
-the functionality introduced in CF-1.9 for the domain variable, which
-also has dimensions but no data).
+the functionality introduced in CF-1.9 for the CF domain variable,
+which has dimensions but no data).
 
 
 ## Terminology
@@ -69,7 +69,7 @@ that defines the *aggregated data*.
 ## Identification of Conventions
 
 Files that follow this version of the CFA Conventions must indicate
-this by setting the NetCDF User’s Guide [NUG] defined global attribute
+this by setting the NetCDF User's Guide [NUG] defined global attribute
 **`Conventions`** to a string value that contains `"CFA-0.6"`, in
 addition to any other conventions that define other aspects of the
 file structure and metadata. For instance, a dataset which follows
@@ -951,7 +951,7 @@ Prototype version
 Prototype version. First introduction of `location`, `file`, `format`
 and `address` variables.
 
-**Version 0.6, 2021-06-21**
+**Version 0.6, *Date to be fixed*
 
 First stable release.
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -1,4 +1,4 @@
-# NetCDF CF Aggregation (CFA) Conventions
+# NetCDF Climate and Forecast Aggregation (CFA) Conventions
 
 David Hassell, Jonathan Gregory, Neil Massey, Bryan Lawrence, Sadie
 Bartholomew
@@ -8,46 +8,44 @@ Version 0.6, 2021-06-??
 ## Introduction
 
 This document describes the CFA (Climate and Forecast Aggregation)
-conventions for storing a netCDF climate and forecast file which does
-not contain the data of selected variables ("aggregation variables"),
-rather those variables contain special metadata that provide
-instructions on how to create their data as an aggregation of data
-from other sources, which may be self-describing datasets in their own
-right.
+conventions for storing a file created with the netCDF Application
+Programmer Interface [NetCDF] which does not contain the data of
+selected variables ("aggregation variables"), rather those variables
+contain special metadata that provide instructions on how to create
+their data as an aggregation of data from other sources, which may be
+self-describing datasets in their own right.
 
 In general, netCDF variables always contain their own data and
 dimensions. An aggregation variable, however, still needs to be
 viewable as if it were a usual netCDF variable even though it does not
-contain its data and dimensions in the usual manner. This is achieved
-by converting the variable to be scalar (with arbitrary single value)
-and providing extra variable attributes from which both the variable's
-true dimensionality can be inferred, and the variable's aggregeted
-data can be constructed.
+contain its data, and therefore nor its dimensions, in the usual
+manner. This is achieved by converting the variable to be scalar (with
+arbitrary single value) and providing extra variable attributes from
+which the variable's true dimensionality can be inferred, and the
+variable's aggregated data can be constructed.
 
 The CFA conventions only apply to the data definition of selected
 variables, so the CFA conventions have been designed to work alongside
 the CF (Climate and Forecast) conventions that specify the geophysical
 meaning of all variables in the file, whether their data are defined
-as aggregations or not. The CFA conventions do not duplicate nor
-re-define any of the metadata elements defined by the CF conventions,
-but a small extension to CF is needed to allow the correct
-interpretation of the dimensionality of aggregation variables
-(effectively a duplication of the functionality introduced in CF-1.9
-for the domain variable, which also has dimensions but no data).
-
-A CFA-netCDF file is a view of a dataset that has been distributed
-across multiple files and storage systems, which contains exactly the
-same information as the dataset that could be created by copying all
-of the distributed files into a single CF-netCDF file.
+as aggregations or not. The CFA conventions do not duplicate, extend,
+nor re-define any of the metadata elements defined by the CF
+conventions. However, when CF-compliant software is used for reading
+the discovery metadata of a CFA-netCDF file, with no expectation of
+reading the data of aggregated variables, a small extension is needed
+to allow the correct interpretation of the dimensionality of
+aggregation variables (effectively a duplication of the functionality
+introduced in CF-1.9 for the domain variable, which also has
+dimensions but no data).
 
 ## Identification of Conventions
 
 Files that follow this version of the CFA Conventions must indicate
-this by setting the CF defined global attribute **`Conventions`** to a
-string value that contains `"CFA-0.6"`, in addition to the version of
-the CF conventions that otherwise define the file structure and
-geophysical metadata. For instance, a dataset which follows CF-1.9 and
-also, for some of its variables, CFA-0.6 could have a **`Conventions`**
+this by setting the NetCDF User’s Guide (NUG) [NUG] defined global
+attribute **`Conventions`** to a string value that contains
+`"CFA-0.6"`, in addition to any other conventions that define other
+aspect of the file structure and metadata. For instance, a dataset
+which follows CF-1.9 and also CFA-0.6 could have a **`Conventions`**
 attribute of `"CF-1.9 CFA-0.6"`.
 
 
@@ -84,7 +82,7 @@ contain some or all of the *fragments*.
 
 ## Aggregation variables
 
-A *aggregation variable* does not contain its own data, as is ususal
+A *aggregation variable* does not contain its own data, as is usual
 for CF-netCDF variables, instead it contains instructions on how to
 create its data as an aggregation of data from other sources.
 
@@ -125,7 +123,7 @@ variables that do not have aggregated data.
 The dimensions listed by the **`aggregated_dimensions`** attribute
 constrain the dimensions that may be spanned by variables referenced
 from any of the other attributes, in the same way that the array
-dimensions perform that role for a ususal CF-netCDF variable. For
+dimensions perform that role for a usual CF-netCDF variable. For
 instance, all variables named by the **`cell_measures`** attribute of
 an aggregated data variable must span a subset of zero or more of the
 dimensions given by the **`aggregated_dimensions`** attribute; or the
@@ -940,3 +938,6 @@ values 270.0, 270.1, ... 271.1.
 
 ## References
 
+[NetCDF] NetCDF Software Package. UNIDATA Program Center of the University Corporation for Atmospheric Research. http://www.unidata.ucar.edu/netcdf/index.html
+
+[NUG] The NetCDF User’s Guide for NetCDF version 4.4.1.1. http://www.unidata.ucar.edu/software/netcdf/docs/user_guide.html

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -953,6 +953,8 @@ Prototype versions
 _Version 0.4, 2014-02-27_ 
 Prototype version
 
+
+
 -Version 0.5, 2021_ 
 Prototype version. First introduction of `location`, `file`, `format`
 and `address` variables.

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -1,39 +1,35 @@
-# CF Aggregation (CFA) Conventions
-
----
+# NetCDF CF Aggregation (CFA) Conventions
 
 David Hassell, Jonathan Gregory, Neil Massey, Bryan Lawrence, Sadie
 Bartholomew
 
 Version 0.6, 2021-06-??
 
----
 
 ## Abstract
 
 This document describes the CFA (Climate and Forecast Aggregation)
-conventions for storing climate and forecast datasets which do not
-contain the data of selected variables, rather those variables contain
-metadata that provide instructions on how to create their data as an
-aggregation of data from other sources. The CFA conventions are only
-concerned with the aggregation of external data sources, and must be
-used in conjunction with the CF (Climate and Forecast) metadata
+conventions for storing netCDF climate and forecast datasets which do
+not contain the data of selected variables, rather those variables
+contain metadata that provide instructions on how to create their data
+as an aggregation of data from other sources. The CFA conventions are
+only concerned with the aggregation of external data sources, and must
+be used in conjunction with the CF (Climate and Forecast) metadata
 conventions, that provide all of the metadata required to physically
 interpret geoscientific variables.
 
----
 
 ## Introduction
 
-Some backgound here ... on the need and what the CFA convnetions provide
+Some backgound here ... 
 
-When a variable's data may be wholly specified by the aggregation of
-the data of other variables, the CFA (Climate and Forecast
-Aggregation) conventions provide a framework for describing how to
-create that aggregation, and this may be used instead of creating the
-entire aggregation in the file as the variable's data as is ususal in
-netCDF files. A variable encoded in this manner is called an
-"aggregation variable".
+When a netCDF variable's data may be wholly specified by the
+aggregation of the data of other variables, the CFA (Climate and
+Forecast Aggregation) conventions provide a framework for describing
+how to create that aggregation, and this may be used instead of
+creating the entire aggregation in the file as the variable's data, as
+is ususal in netCDF files. A variable encoded in this manner is called
+an "aggregation variable".
 
 In general, netCDF variables always contain their own data and
 dimensions, but for an aggregation variable no actual data in the file
@@ -57,7 +53,6 @@ the metadata when the data is not present in the file (effectively a
 duplication of the functionality introduced in CF-1.9 for the domain
 variable)
 
----
 
 ## Identification of Conventions
 
@@ -69,7 +64,6 @@ geophysical metadata. For instance, a dataset which follows CF-1.9 and
 also, for some of its variables, CFA-0.6 could have a **`Conventions`**
 attribute of `"CF-1.9 CFA-0.6"`.
 
----
 
 ## Terminology
 
@@ -101,7 +95,6 @@ that defines the *aggregated data*.
 The netCDF file that contains the *aggregated variable*, and may also
 contain some or all of the *fragments*.
 
----
 
 ## Aggregation variables
 
@@ -288,6 +281,7 @@ instruction terms, all of which are mandatory, are:
 * Addressing for other file formats is allowed, but not described in
   these conventions.
 
+
 #### Example 1
 
 An aggregated data variable whose aggregated data comprises two
@@ -353,7 +347,7 @@ external files are netCDF files, the `format` term of the
       aggregation_address = "temp", "temp" ;
 
 
-### Fragment Storage
+## Fragment Storage
 
 Each fragment has a generic form for which:
 
@@ -387,7 +381,7 @@ the application program that is managing the aggregation.
 
 The following fragment manipulations are allowed:
 
-#### Units
+### Units
  
 If a fragment has no defined units then its data is assumed to have
 the same units as the aggregated variable.
@@ -411,7 +405,8 @@ For instance, if the aggregation variable units are `"days since
 of the fragment's units are changed to the earlier date by adding 365
 to the fragment's data.
 
-#### Missing size 1 dimensions
+
+### Missing size 1 dimensions
 
 A fragment may omit from its data any size 1 dimension for which the
 size of the fragment's location along the corresponding aggregated
@@ -421,7 +416,8 @@ instance, if the fragment's shape defined by the `location` term of
 the aggregation instructions is `(6, 1, 73, 144)`, then the fragment's
 data could have shape `(6, 1, 73, 144)` or `(6, 73, 144)`.
 
-#### Compression
+
+### Compression
 
 A fragment may be stored in any compressed form, i.e. stored using
 fewer bits than its original uncompressed representation, for which
@@ -433,7 +429,8 @@ prior to insertion into the aggregated data. In this case, the
 the uncompressed fragment and the data type of the fragment is the
 data type of its uncompressed data.
 
-#### Missing values
+
+### Missing values
 
 A fragment may use any valid means for defining missing
 values. Missing values must be changed to values that the aggregation
@@ -441,7 +438,8 @@ variable recognises as missing. It is up to the creator of the dataset
 to ensure that non-missing values in a fragment are not registered as
 missing in the aggregated data.
 
-#### Example 2
+
+### Example 2
 
 An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
@@ -691,6 +689,7 @@ used in the aggregated data.
                  "temp4", _ ;
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
 
+
 #### Example 5
 
 An aggregated data variable and an aggregated coordinate variable in
@@ -780,7 +779,8 @@ apply to both aggregation variables.
                    6, 11 ;
         address = "time", "time" ;
    }
-   
+
+
 #### Example 6
 
 An aggregation data variable for a collection of discrete sampling
@@ -934,7 +934,6 @@ values 270.0, 270.1, ... 271.1.
         address = "/aggregation/temp1", "/aggregation/temp2" ;
    }
 
----
 
 ## References
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -117,19 +117,26 @@ will identify an aggregation variable, therefore the
 **`aggregated_dimensions`** attribute must not be present on any
 variables that do not have aggregated data.
 
-The dimensions listed by the **`aggregated_dimensions`** attribute
+When the correct interpretation of an aggregation variable requires
+knowledge of its dimensions, the dimensions listed by the
+**`aggregated_dimensions`** attribute should be treated as if they
+were the variable's dimensions encoded in the usual netCDF manner.
+
+#### Example 1
+
+*For an aggregation variable that follows the CF conventions, the
+dimensions listed by the **`aggregated_dimensions`** attribute
 constrain the dimensions that may be spanned by variables referenced
-from any of the other attributes, in the same way that the array
-dimensions perform that role for a usual CF-netCDF variable. For
-instance, all variables named by the **`cell_measures`** attribute of
-an aggregated data variable must span a subset of zero or more of the
-dimensions given by the **`aggregated_dimensions`** attribute; or the
-variable named by the **`bounds`** attribute of an aggregated CF
-coordinate variable must span all of the aggregated dimensions in the
-same order, as well as the trailing bounds dimension. Any CF
-coordinate variable that shares its name with an aggregated dimension
-of an aggregated data variable will be considered as part of the data
-variable's CF domain definition.
+from any of the other attributes. For instance, all variables named by
+the **`cell_measures`** attribute of an aggregated CF data variable
+must span a subset of zero or more of the dimensions given by the
+**`aggregated_dimensions`** attribute; or the variable named by the
+**`bounds`** attribute of an aggregated CF coordinate variable must
+span all of the aggregated dimensions in the same order, as well as
+the trailing bounds dimension. Any CF coordinate variable that shares
+its name with an aggregated dimension of an aggregated CF data
+variable will be considered as part of the CF data variable's CF
+domain definition.*
 
 The fragments are organised into an orthogonal multidimensional array
 with the same number of dimensions as the aggregated data. Each
@@ -266,12 +273,12 @@ which are mandatory, are:
   these conventions.
 
 
-#### Example 1
+#### Example 2
 
-An aggregated data variable whose aggregated data comprises two
+*An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
 and the whole of the other three aggregated dimensions, and is stored
-in an external netCDF file in a variable call `temp`.
+in an external netCDF file in a variable call `temp`.*
 
     dimensions:
       // Aggregated dimensions
@@ -430,15 +437,15 @@ to ensure that non-missing values in a fragment are not registered as
 missing in the aggregated data.
 
 
-#### Example 2
+#### Example 3
 
-An aggregated data variable whose aggregated data comprises two
+*An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
 and the whole of the other three aggregated dimensions. One fragment
 is stored in an external file and the other is stored in the same
 dataset as variable `temp2`. The fragment stored in the same dataset
 has different but equivalent units to the aggregation variable, and
-omits the size 1 `level` dimension.
+omits the size 1 `level` dimension.*
 
     dimensions:
       // Aggregated dimensions
@@ -506,9 +513,9 @@ omits the size 1 `level` dimension.
       temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
 
 
-#### Example 3
+#### Example 4
 
-An aggregated data variable whose aggregated data comprises two
+*An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment is stored in the same dataset and spans half
 of the aggregated `time` dimension and the whole of the `latitude` and
 `longitude` dimensions, but does not span the size 1 `level`
@@ -516,7 +523,7 @@ dimension. As there are no external files, the `file` and `format`
 variables both contain missing data. The fragments and aggregation
 definition variables in this case are stored in a child group called
 `aggregation`. The `temp2` fragment has different but equivalent units
-to the aggregation variable.
+to the aggregation variable.*
 
     dimensions:
       // Aggregated dimensions
@@ -593,9 +600,9 @@ to the aggregation variable.
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
     }
 
-#### Example 4
+#### Example 5
 
-An aggregated data variable whose aggregated data comprises four
+*An aggregated data variable whose aggregated data comprises four
 fragments. Each fragment spans half of the aggregated `time`
 dimension, either the northern or southern hemisphere, and the whole
 of the other two aggregated dimensions. The fragments are stored in
@@ -604,7 +611,7 @@ in a child group called `aggregation`. One of the fragments has been
 defined by two different external resources (one "local" and one
 "remote"), each of which is provided with its own address within its
 file (`temp3` and `t3` respectively). Either of these resources, but
-not both, may be used in the aggregated data.
+not both, may be used in the aggregated data.*
 
     dimensions:
       // Aggregated dimensions
@@ -700,16 +707,16 @@ not both, may be used in the aggregated data.
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
     }
 
-#### Example 5
+#### Example 6
 
-An aggregated data variable and an aggregated coordinate variable in
+*An aggregated data variable and an aggregated coordinate variable in
 the same dataset. There are two external netCDF files, each of which
 contains a fragment for each aggregation variable. The aggregation
 definition variables for each aggregation variable are stored in
 different groups (`aggregation_temp` and `aggregation_time`), but the
 `file` terms of the **`aggregated_data`** attributes refer to a
 variable in the root group that stores the external file names that
-apply to both aggregation variables.
+apply to both aggregation variables.*
 
     dimensions:
       // Aggregated dimensions
@@ -796,15 +803,15 @@ apply to both aggregation variables.
     }
 
 
-#### Example 6
+#### Example 7
 
-An aggregation data variable for a collection of discrete sampling
+*An aggregation data variable for a collection of discrete sampling
 geometry timeseries features that have been compressed by use of a
 contiguous ragged array. The three timeseries of air temperature are
 each from different geographical locations and comprise four, five,
 and six observations respectively, giving a total of fifteen
 observations. The timeseries from each location is stored in a
-separate external file.
+separate external file.*
 
     dimensions:
       // Aggregated dimensions
@@ -887,14 +894,14 @@ separate external file.
       aggregation_address_lon = "lon", "lon", "lon" ;
 
 
-#### Example 7
+#### Example 8
 
-An aggregation data variable whose aggregated data represents 32-bit
+*An aggregation data variable whose aggregated data represents 32-bit
 floats packed into 16-bit integers. When created, the aggregated data
 contains the 16-bit integer values 0, 5958,..., 65539. These may be
 subsequently unpacked to the 32-bit float values 270.0, 270.1, ...,
 271.10007, which approximate the original, pre-packed 32-bit float
-values 270.0, 270.1, ... 271.1.
+values 270.0, 270.1, ... 271.1.*
 
     dimensions:
       // Aggregated dimensions

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -788,7 +788,7 @@ apply to both aggregation variables.
         location = 0, 5,
                    6, 11 ;
         address = "time", "time" ;
-   }
+    }
 
 
 #### Example 6

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -123,23 +123,25 @@ variables that do not have aggregated data.
 When the correct interpretation of an aggregation variable requires
 knowledge of its dimensions, the dimensions listed by the
 **`aggregated_dimensions`** attribute should be treated as if they
-were the variable's dimensions encoded in the usual netCDF manner.
+were the variable dimensions encoded in the usual netCDF manner.
 
-#### Example 1
-
-*For an aggregation variable that follows the CF conventions, the
-dimensions listed by the **`aggregated_dimensions`** attribute
-constrain the dimensions that may be spanned by variables referenced
-from any of the other attributes. For instance, all variables named by
-the **`cell_measures`** attribute of an aggregated CF data variable
-must span a subset of zero or more of the dimensions given by the
-**`aggregated_dimensions`** attribute; or the variable named by the
-**`bounds`** attribute of an aggregated CF coordinate variable must
-span all of the aggregated dimensions in the same order, as well as
-the trailing bounds dimension. Any CF coordinate variable that shares
-its name with an aggregated dimension of an aggregated CF data
-variable will be considered as part of the CF data variable's CF
-domain definition.*
+A variable that follows the CF conventions often has attributes that
+reference other variables which contain metadata that describes the
+parent variable. The dimensions spanned by such metadata variables are
+constrained by the parent variable dimensions. For instance, all
+variables named by the **`cell_measures`** attribute of a CF data
+variable must span a subset of zero or more of the parent variable
+dimensions; or the variable named by the **`bounds`** attribute of a
+CF coordinate variable must span all of the parent variable dimensions
+in the same order, as well as the trailing bounds dimension. An
+aggregated variable that follows the CF conventions applies these
+rules in a similar manner, except that the metadata variable
+dimensions are constrained by the aggregated dimensions, i.e. the
+ordered list of dimensions given by the **`aggregated_dimensions`**
+attribute. In particular, note that any CF coordinate variable that
+shares its name with an aggregated dimension of an aggregated CF data
+variable is be considered as part of that variable's CF domain
+definition.
 
 The fragments are organised into an orthogonal multidimensional array
 with the same number of dimensions as the aggregated data. Each
@@ -286,7 +288,7 @@ which are mandatory, are:
   these conventions.
 
 
-#### Example 2
+#### Example 1
 
 *An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
@@ -453,7 +455,7 @@ to ensure that non-missing values in a fragment are not registered as
 missing in the aggregated data.
 
 
-#### Example 3
+#### Example 2
 
 *An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
@@ -529,7 +531,7 @@ omits the size 1 `level` dimension.*
       temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
 
 
-#### Example 4
+#### Example 3
 
 *An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment is stored in the same dataset and spans half
@@ -617,7 +619,7 @@ to the aggregation variable.*
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
     }
 
-#### Example 5
+#### Example 4
 
 *An aggregated data variable whose aggregated data comprises four
 fragments. Each fragment spans half of the aggregated `time`
@@ -721,7 +723,7 @@ not both, may be used in the aggregated data.*
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
     }
 
-#### Example 6
+#### Example 5
 
 *An aggregated data variable and an aggregated coordinate variable in
 the same dataset. There are two external netCDF files, each of which
@@ -818,7 +820,7 @@ apply to both aggregation variables.*
     }
 
 
-#### Example 7
+#### Example 6
 
 *An aggregation data variable for a collection of discrete sampling
 geometry timeseries features that have been compressed by use of a
@@ -910,7 +912,7 @@ separate external file.*
       aggregation_address_lon = "lon", "lon", "lon" ;
 
 
-#### Example 8
+#### Example 7
 
 *An aggregation data variable whose aggregated data represents 32-bit
 floats packed into 16-bit integers. When created, the aggregated data

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -947,17 +947,17 @@ values 270.0, 270.1, ... 271.1.
 
 ## Revision History
 
-**Versions 0.1 to 0.3, 2012 to 2013\ **
+_Versions 0.1 to 0.3, 2012 to 2013_ 
 Prototype versions
 
-**Version 0.4, 2014-02-27\ **
+_Version 0.4, 2014-02-27_ 
 Prototype version
 
-**Version 0.5, 2021\ **
+-Version 0.5, 2021_ 
 Prototype version. First introduction of `location`, `file`, `format`
 and `address` variables.
 
-**Version 0.6, 2021-06-??\ **
+_Version 0.6, 2021-06-??_ 
 First stable release.
 
 ## References

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -20,10 +20,10 @@ In general, netCDF variables always contain their own data and
 dimensions. An aggregation variable, however, does not contain its
 data&mdash;and therefore nor its dimensions&mdash;in the usual manner
 and yet still needs to be viewable as if it were a usual netCDF
-variable. This is achieved by encoding the variable as a scalar (with
-arbitrary single value) and providing extra variable attributes from
-which the variable's true dimensionality can be inferred, and the
-variable's aggregated data can be constructed.
+variable. This is achieved by encoding the aggregation variable as a
+scalar (with arbitrary single value) and providing extra variable
+attributes from which the variable's true dimensionality can be
+inferred, and the variable's aggregated data can be constructed.
 
 The CFA conventions only apply to the data definition of selected
 variables, so the CFA conventions have been designed to work alongside
@@ -38,16 +38,6 @@ extension is needed to allow the correct interpretation of the
 dimensionality of aggregation variables (effectively a duplication of
 the functionality introduced in CF-1.9 for the domain variable, which
 also has dimensions but no data).
-
-## Identification of Conventions
-
-Files that follow this version of the CFA Conventions must indicate
-this by setting the NetCDF User’s Guide [NUG] defined global attribute
-**`Conventions`** to a string value that contains `"CFA-0.6"`, in
-addition to any other conventions that define other aspects of the
-file structure and metadata. For instance, a dataset which follows
-CF-1.9 and also CFA-0.6 could have a **`Conventions`** attribute of
-`"CF-1.9 CFA-0.6"`.
 
 
 ## Terminology
@@ -74,6 +64,17 @@ composed from a multi-dimensional orthogonal array of fragments.
 
 A dimension of the multi-dimensional orthogonal array of fragments
 that defines the *aggregated data*.
+
+
+## Identification of Conventions
+
+Files that follow this version of the CFA Conventions must indicate
+this by setting the NetCDF User’s Guide [NUG] defined global attribute
+**`Conventions`** to a string value that contains `"CFA-0.6"`, in
+addition to any other conventions that define other aspects of the
+file structure and metadata. For instance, a dataset which follows
+CF-1.9 and also CFA-0.6 could have a **`Conventions`** attribute of
+`"CF-1.9 CFA-0.6"`.
 
 
 ## Aggregation variables

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -229,11 +229,21 @@ which are mandatory, are:
 * Names the string-valued variable containing the case-insensitive
   file formats for fragments stored in external files.
 
-* The `format` variable must span exactly the same dimensions in the
-  same order as the `file` variable. Missing values must be used
-  whenever the corresponding location in the `file` variable is a
-  missing value.
+* The `format` variable must either be scalar or span exactly the same
+  dimensions in the same order as the `file` variable.
   
+* When the `format` variable spans the same dimensions as the `file`
+  variable, missing values must be used whenever the corresponding
+  location in the `file` variable is a missing value.
+  
+* A scalar `format` variable is a convenience feature that may be used
+  when all fragment files have the same format. In this case the
+  single value is assumed to apply to all fragments that have a file
+  representation, i.e. those fragments that correspond to non-missing
+  values in the `file` variable. If the `file` variable contains only
+  missing values, then the `format` variable is not used, and so may
+  take an arbitrary value.
+    
 * A fragment in an external netCDF file is signified by a value of
   `nc`.
 
@@ -281,7 +291,9 @@ which are mandatory, are:
 *An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
 and the whole of the other three aggregated dimensions, and is stored
-in an external netCDF file in a variable call `temp`.*
+in an external netCDF file in a variable call `temp`. Both fragment
+files have the same format, so the `format` variable can be stored as
+a scalar variable.*
 
     dimensions:
       // Aggregated dimensions
@@ -324,7 +336,7 @@ in an external netCDF file in a variable call `temp`.*
       // Aggregation definition variables			 	  
       int aggregation_location(f_time, f_level, f_latitude, f_longitude, i, j) ;
       string aggregation_file(f_time, f_level, f_latitude, f_longitude) ;
-      string aggregation_format(f_time, f_level, f_latitude, f_longitude) ;
+      string aggregation_format ;
       string aggregation_address(f_time, f_level, f_latitude, f_longitude) ;
 
     // global attributes:
@@ -341,7 +353,7 @@ in an external netCDF file in a variable call `temp`.*
                              0, 72,
                              0, 143 ;
       aggregation_file = "January-June.nc", "July-December.nc" ;
-      aggregation_format = "nc", "nc" ;
+      aggregation_format = "nc" ;
       aggregation_address = "temp", "temp" ;
 
 
@@ -492,7 +504,7 @@ omits the size 1 `level` dimension.*
       // Aggregation definition variables			 	  
       int aggregation_location(f_time, f_level, f_latitude, f_longitude, i, j) ;
       string aggregation_file(f_time, f_level, f_latitude, f_longitude) ;
-      string aggregation_format(f_time, f_level, f_latitude, f_longitude) ;
+      string aggregation_format ;
       string aggregation_address(f_time, f_level, f_latitude, f_longitude) ;
       // Fragment variable
       double temp2(time, latitude, longitude) ;
@@ -512,7 +524,7 @@ omits the size 1 `level` dimension.*
                              0, 72,
                              0, 143 ;
       aggregation_file = "January-June.nc", _ ;
-      aggregation_format = "nc", _ ;
+      aggregation_format = "nc" ;
       aggregation_address = "temp", "temp2" ;
       temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
 
@@ -523,8 +535,9 @@ omits the size 1 `level` dimension.*
 fragments. Each fragment is stored in the same dataset and spans half
 of the aggregated `time` dimension and the whole of the `latitude` and
 `longitude` dimensions, but does not span the size 1 `level`
-dimension. As there are no external files, the `file` and `format`
-variables both contain missing data. The fragments and aggregation
+dimension. As there are no external files, the `file` variable
+contains only missing values, and therefore the `format` variable may
+also be a scalar missing value. The fragments and aggregation
 definition variables in this case are stored in a child group called
 `aggregation`. The `temp2` fragment has different but equivalent units
 to the aggregation variable.*
@@ -580,7 +593,7 @@ to the aggregation variable.*
         // Aggregation definition variables
         int location(f_time, f_level, f_latitude, f_longitude, i, j) ;
         string file(f_time, f_level, f_latitude, f_longitude) ;
-        string format(f_time, f_level, f_latitude, f_longitude) ;
+        string format ;
         string address(f_time, f_level, f_latitude, f_longitude) ;
         // Fragment variables
         double temp1(time, latitude, longitude) ;
@@ -598,7 +611,7 @@ to the aggregation variable.*
                    0, 72,
                    0, 143 ;
        file = _, _ ;
-       format = _, _ ;
+       format = _ ;
        address = "temp1", "temp2" ;
        temp1 = 270.3, 272.5, 274.1, 278.5, 280.3, 283.6, ... ;
        temp2 = 4.5, 3.0, 0.0, -2.6, -5.6, -10.2, ... ;
@@ -672,7 +685,7 @@ not both, may be used in the aggregated data.*
         // Aggregation definition variables			 	  
         int location(f_time, f_level, f_latitude, f_longitude, i, j) ;
         string file(f_time, f_level, f_latitude, f_longitude, k) ;
-        string format(f_time, f_level, f_latitude, f_longitude, k) ;
+        string format ;
         string address(f_time, f_level, f_latitude, f_longitude, k) ;
         // Fragment variable
         double temp2(time, latitude, longitude) ;
@@ -700,10 +713,7 @@ not both, may be used in the aggregated data.*
               _, _,
               "/local/January-June_NH.nc", "/remote/January-June_NH.nc",
               "/remote/July-December_NH.nc", _ ;
-       format = "nc, _,
-                _, _,
-                "nc", "nc",
-                "nc", _ ;
+       format = "nc" ;
        address = "temp1", _,
                  "temp2", _,
                  "temp3", "t3",
@@ -767,6 +777,7 @@ apply to both aggregation variables.*
         longitude:units = "degrees_east" ;
       // Aggregation definition variable
       string aggregation_file(f_time, f_level, f_latitude, f_longitude) ;
+      string aggregation_format ;
 
     // global attributes:
       :Conventions = "CF-1.9 CFA-0.6" ;
@@ -774,7 +785,7 @@ apply to both aggregation variables.*
       temp = _ ;
       time = _ ;
       aggregation_file = "January-June.nc", "July-December.nc" ;
-      aggregation_format = "nc", "nc" ;
+      aggregation_format = "nc" ;
 
     group: aggregation_temp {
       variables:
@@ -872,6 +883,7 @@ separate external file.*
       // Aggregation definition variables			 	  
       int aggregation_location(f_station, i, j) ;
       string aggregation_file(f_station) ;
+      string aggregation_format ;
       string aggregation_address_temp(f_station) ;
       string aggregation_address_time(f_station) ;
       string aggregation_address_lat(f_station) ;
@@ -891,7 +903,7 @@ separate external file.*
                                     1, 1
                                     2, 2 ;
       aggregation_file = "Harwell.nc", "Abingdon.nc", "Lambourne.nc" ;
-      aggregation_format = "nc", "nc", "nc" ;
+      aggregation_format = "nc" ;
       aggregation_address_temp = "tas", "tas", "tas" ;
       aggregation_address_time = "time", "time", "time" ;
       aggregation_address_lat = "lat", "lat", "lat" ;
@@ -950,7 +962,7 @@ values 270.0, 270.1, ... 271.1.*
         // Aggregation definition variables
         int location(f_time, i, j) ;
         string file(f_time) ;
-        string format(f_time) ;	
+        string format ;	
         string address(f_time) ;
       
       data:    	  
@@ -959,7 +971,7 @@ values 270.0, 270.1, ... 271.1.*
         location = 0, 5,
                    6, 11,
         file = _, _ ;
-        format = _, _ ;
+        format = _ ;
         address = "/aggregation/temp1", "/aggregation/temp2" ;
     }
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -3,7 +3,7 @@
 David Hassell, Jonathan Gregory, Neil Massey, Bryan Lawrence, Sadie
 Bartholomew
 
-**Version 0.6b1**, 2021-07-??
+**Version 0.6**, 2021-07-27
 
 
 ## Introduction
@@ -969,20 +969,20 @@ values 270.0, 270.1, ... 271.1.*
 
 ## Revision History
 
-**Versions 0.1 to 0.3, 2012 to 2013**
+**Versions 0.1 to 0.3**, 2012 to 2013
 
 Prototype versions
 
-**Version 0.4, 2014-02-27**
+**Version 0.4**, 2014-02-27
 
 Prototype version
 
-**Version 0.5, 2021**
+**Version 0.5**, 2021
 
 Prototype version. First introduction of `location`, `file`, `format`
 and `address` variables.
 
-**Version 0.6, *Date to be fixed*
+**Version 0.6**, 2021-07-27
 
 First stable release.
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -8,12 +8,15 @@ Bartholomew
 
 ## Introduction
 
-This document describes the CFA (Climate and Forecast Aggregation)
-conventions for storing a file created with the netCDF Application
-Programmer Interface [NetCDF] which does not contain the data of
-selected variables ("aggregation variables"), rather those variables
-contain special attributes that provide instructions on how to create
-their data as an aggregation of data from other sources, which may be
+
+The CFA (Climate and Forecast Aggregation) conventions describe how a
+netCDF [NetCDF] file can be used to describe a dataset distributed
+across multiple other data files. A CFA-compliant aggregation can be
+described in netCDF in such way that the describing file does not
+contain the data of selected variables ("aggregation variables"),
+rather it contains variables with special attributes that provide
+instructions on how to create the aggregated variable data as an
+aggregation of data from other sources, each of which may be
 self-describing datasets in their own right.
 
 In general, netCDF variables always contain their own data and

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -669,7 +669,7 @@ not both, may be used in the aggregated data.*
         // Aggregation definition variables			 	  
         int location(f_time, f_level, f_latitude, f_longitude, i, j) ;
         string file(f_time, f_level, f_latitude, f_longitude, k) ;
-	string format(f_time, f_level, f_latitude, f_longitude, k) ;
+        string format(f_time, f_level, f_latitude, f_longitude, k) ;
         string address(f_time, f_level, f_latitude, f_longitude, k) ;
         // Fragment variable
         double temp2(time, latitude, longitude) ;

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -16,15 +16,6 @@ their data as an aggregation of data from other sources, which may be
 self-describing datasets in their own right.
 
 In general, netCDF variables always contain their own data and
-dimensions. An aggregation variable, however, still needs to be
-viewable as if it were a usual netCDF variable even though it does not
-contain its data, and therefore nor its dimensions, in the usual
-manner. This is achieved by converting the variable to be scalar (with
-arbitrary single value) and providing extra variable attributes from
-which the variable's true dimensionality can be inferred, and the
-variable's aggregated data can be constructed.
-
-In general, netCDF variables always contain their own data and
 dimensions. An aggregation variable, however, does not contain its
 data&mdash;and therefore nor its dimensions&mdash;in the usual manner
 and yet still needs to be viewable as if it were a usual netCDF

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -947,19 +947,19 @@ values 270.0, 270.1, ... 271.1.
 
 ## Revision History
 
-_Versions 0.1 to 0.3, 2012 to 2013_
-: Prototype versions
+**Versions 0.1 to 0.3, 2012 to 2013**
+Prototype versions
 
-_Version 0.4, 2014-02-27_
+**Version 0.4, 2014-02-27*8
 
 Prototype version
 
-_Version 0.5, 2021_
+**Version 0.5, 2021**
 
 Prototype version. First introduction of `location`, `file`, `format`
 and `address` variables.
 
-_Version 0.6, 2021-06-??_
+**Version 0.6, 2021-06-??**
 
 First stable release.
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -315,6 +315,9 @@ in an external netCDF file in a variable call `temp`.
       int aggregation_location(f_time, f_level, f_latitude, f_longitude, i, j) ;
       string aggregation_file(f_time, f_level, f_latitude, f_longitude) ;
       string aggregation_address(f_time, f_level, f_latitude, f_longitude) ;
+
+    // global attributes:
+      :Conventions = "CF-1.9 CFA-0.6" ;
     data:
       temp = _ ;
       time = 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 ;
@@ -483,7 +486,9 @@ omits the size 1 `level` dimension.
       // Fragment variable
       double temp2(time, latitude, longitude) ;
         temp:units = "degreesC" ;
-	
+
+    // global attributes:
+      :Conventions = "CF-1.9 CFA-0.6" ;
     data:
       temp = _ ;
       time = 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 ;
@@ -543,6 +548,9 @@ to the aggregation variable.
       double longitude(longitude) ;
         longitude:standard_name = "longitude" ;
         longitude:units = "degrees_east" ;
+
+    // global attributes:
+      :Conventions = "CF-1.9 CFA-0.6" ;
     data:
       temp = _ ;
       time = 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 ;
@@ -628,6 +636,9 @@ not both, may be used in the aggregated data.
       double longitude(longitude) ;
         longitude:standard_name = "longitude" ;
         longitude:units = "degrees_east" ;
+
+    // global attributes:
+      :Conventions = "CF-1.9 CFA-0.6" ;
     data:
       temp = _ ;
       time = 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 ;
@@ -746,6 +757,8 @@ apply to both aggregation variables.
       // Aggregation definition variable
       string aggregation_file(f_time, f_level, f_latitude, f_longitude) ;
 
+    // global attributes:
+      :Conventions = "CF-1.9 CFA-0.6" ;
     data:
       temp = _ ;
       time = _ ;
@@ -854,6 +867,7 @@ separate external file.
       string aggregation_address_lon(f_station) ;
 
     // global attributes:
+      :Conventions = "CF-1.9 CFA-0.6" ;
       :featureType = "timeSeries";
     data:
       temp = _ ;    
@@ -902,7 +916,9 @@ values 270.0, 270.1, ... 271.1.
       float time(time) ;
         time:standard_name = "time" ;
         time:units = "days since 2001-01-01" ;
-    	
+
+    // global attributes:
+      :Conventions = "CF-1.9 CFA-0.6" ;
     data:
       temp = _ ;
       time = 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 ;

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -35,17 +35,17 @@ variable's aggregated data can be constructed.
 
 The CFA conventions only apply to the data definition of selected
 variables, so the CFA conventions have been designed to work alongside
-the CF (Climate and Forecast) conventions that specify the geophysical
-meaning of all variables in the file, whether their data are defined
-as aggregations or not. The CFA conventions do not duplicate, extend,
-nor re-define any of the metadata elements defined by the CF
-conventions. However, when CF-compliant software is used for reading
-the discovery metadata of a CFA-netCDF file, with no expectation of
-reading the data of aggregated variables, a small extension is needed
-to allow the correct interpretation of the dimensionality of
-aggregation variables (effectively a duplication of the functionality
-introduced in CF-1.9 for the domain variable, which also has
-dimensions but no data).
+the CF (Climate and Forecast) conventions [CF] that specify the
+geophysical meaning of all variables in the file, whether their data
+are defined as aggregations or not. The CFA conventions do not
+duplicate, extend, nor re-define any of the metadata elements defined
+by the CF conventions. However, when CF-compliant software is used for
+reading the discovery metadata of a CFA-netCDF file, with no
+expectation of reading the data of aggregated variables, a small
+extension is needed to allow the correct interpretation of the
+dimensionality of aggregation variables (effectively a duplication of
+the functionality introduced in CF-1.9 for the domain variable, which
+also has dimensions but no data).
 
 ## Identification of Conventions
 
@@ -435,7 +435,7 @@ to ensure that non-missing values in a fragment are not registered as
 missing in the aggregated data.
 
 
-### Example 2
+#### Example 2
 
 An aggregated data variable whose aggregated data comprises two
 fragments. Each fragment spans half of the aggregated `time` dimension
@@ -945,7 +945,24 @@ values 270.0, 270.1, ... 271.1.
    }
 
 
+## Revision History
+
+**Versions 0.1 to 0.3, 2012 to 2013 **
+Prototype versions
+
+**Version 0.4, 2014-02-27 **
+Prototype version
+
+**Version 0.5, 2021 **
+Prototype version. First introduction of `location`, `file`, `format`
+and `address` variables.
+
+**Version 0.6, 2021-06-?? **
+First stable release.
+
 ## References
+
+[CF] NetCDF Climate and Forecast (CF) Metadata Conventions. https://cfconventions.org/cf-conventions/cf-conventions.html
 
 [NetCDF] NetCDF Software Package. UNIDATA Program Center of the University Corporation for Atmospheric Research. http://www.unidata.ucar.edu/netcdf/index.html
 

--- a/source/cfa.md
+++ b/source/cfa.md
@@ -358,11 +358,11 @@ Each fragment has a canonical form for which:
 In particular circumstances, however, a fragment may deviate from
 these requirements providing that it is possible to unambiguously
 convert the fragment to its canonical form prior to it being used
-within the aggregated data. This allows the usability of a fragment in
-the aggregated data to be independent of the fragment's encoding in
-its file. The manipulation of a fragment to its generic form is
-carried out by the application program that is managing the
-aggregation.
+within the aggregated data. This is useful for cases when the framents
+were created independently of the CFA-netCDF file and were encoded
+with forms which are equivalent, but not equal to, the canonical
+form. The manipulation of a fragment to its canonical form is carried
+out by the application program that is managing the aggregation.
 
 The following fragment manipulations are allowed:
 


### PR DESCRIPTION
Previously the document silently assumed that it was part of the CF conventions, which is not to be the case (at this time, at least). This PR aims to make the document independent.