### PR TITLE
Add `CITATION.cff` metadata file for referencing CFA standalone

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,59 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: NetCDF Climate and Forecast Aggregation (CFA) Conventions
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: David
+    family-names: Hassell
+    email: david.hassell@ncas.ac.uk
+    orcid: 'https://orcid.org/0000-0001-5106-7502'
+    affiliation: >-
+      National Centre for Atmospheric Science and University
+      of Reading
+  - given-names: Jonathan
+    family-names: Gregory
+    email: j.m.gregory@reading.ac.uk
+    orcid: 'https://orcid.org/0000-0003-1296-8644'
+    affiliation: >-
+      National Centre for Atmospheric Science and University
+      of Reading and Met Office Hadley Centre
+  - given-names: Neil R.
+    family-names: Massey
+    orcid: 'https://orcid.org/0000-0003-1211-1341'
+    affiliation: >-
+      Science and Technology Facilities Council and National
+      Centre for Atmospheric Science
+  - affiliation: >-
+      National Centre for Atmospheric Science and University
+      of Reading
+    given-names: Bryan N.
+    family-names: Lawrence
+    orcid: 'https://orcid.org/0000-0001-9262-7860'
+    email: bryan.lawrence@ncas.ac.uk
+  - affiliation: >-
+      National Centre for Atmospheric Science and University
+      of Reading
+    given-names: Sadie L.
+    family-names: Bartholomew
+    email: sadie.bartholomew@ncas.ac.uk
+    orcid: 'https://orcid.org/0000-0002-6180-3603'
+url: >-
+  https://github.com/NCAS-CMS/cfa-conventions/blob/main/source/cfa.md
+abstract: >-
+  The CFA (Climate and Forecast Aggregation) conventions
+  describe how a netCDF file can be used to describe a
+  dataset distributed across multiple other data files.
+keywords:
+  - metadata
+  - netCDF
+  - aggregation
+  - CF
+  - climate
+  - forecast
+  - standard
+  - convention


### PR DESCRIPTION
Add `CITATION.cff` metadata file, which is a relatively-new [standard for providing means to cite a repository](https://citation-file-format.github.io/).

Though the intention is to get CFA incorporated into the CF Conventions, with community approval and a PR in preparation at this stage, we agreed it would be useful to also enable citation of CFA on its own (e.g. because there won't be a specific chapter/section in the CF Conventions document dedicated to CFA, it will be referenced instead here and there as relevant), and this file will allow one to do so.

@davidhassell and any other reviewers, please note:
* I used [this dedicated site](https://citation-file-format.github.io/cff-initializer-javascript) to create and validate the file, skipping some optional fields which didn't seem that useful or relevant in this case, but feel free to try it out in case you want o add or remove info I have suggested here in this PR version of the file. One particular field that might be useful is to specific 'version specific' details to tie to a given version/commit, but it looks like there have been plenty of commits since our last release so even if we did want that, I wouldn't be sure what to specify.
* I have tried to ensure correct author info (ORCID and affiliations) from what I can find online, but these should probably be double-checked by everyone involved. 

and feel free to suggest any changes e.g. different keywords and abstract.